### PR TITLE
fix: proton container running check

### DIFF
--- a/pubsub_facades/base.py
+++ b/pubsub_facades/base.py
@@ -128,7 +128,7 @@ class PubSubFacade:
         @wraps(f)
         def decorator(*args, **kwargs):
             self = args[0]
-            if not self.container.is_running():
+            if not self.container.thread_is_running():
                 raise RuntimeError("Action cannot complete because container has not been started yet")
             return f(*args, **kwargs)
         return decorator


### PR DESCRIPTION
This change is made to update the decorator used to check if the container is running, class method: require_running

The update is needed based on refactors made on the SWIM Proton repo. 

See this commit: 
https://github.com/eurocontrol-swim/swim-qpid-proton/commit/502ad4e5fef901751f1b09423cf01b6c9c6d434c

